### PR TITLE
fix: QGIS 3.38 (Qt 6) 対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,95 @@
+# CHANGELOG
+
+## [Unreleased] — QGIS 3.38 対応
+
+### 背景
+
+QGIS 3.38 は Qt 6 ベースに移行し、PyQt5 の一部 API が非推奨・廃止になりました。
+本 PR はその変更に追従し、**QGIS 3.38 以降でも動作**しつつ、**3.38 未満との後方互換**を保ちます。
+
+---
+
+### 新規追加
+
+#### `compat.py`（新規ファイル）
+
+QGIS バージョンによって型定数と列挙値を切り替えるヘルパーモジュールを追加しました。
+
+```python
+# QGIS 3.38+ では QMetaType.Type.* を使用
+# QGIS 3.38 未満では QVariant.* を使用
+if Qgis.versionInt() >= 33800:
+    FIELD_STRING = QMetaType.Type.QString
+    ...
+    DIALOG_ACCEPTED = QDialog.DialogCode.Accepted
+else:
+    FIELD_STRING = QVariant.String
+    ...
+    DIALOG_ACCEPTED = QDialog.Accepted
+```
+
+各ファイルはこのモジュールから定数を import するだけで、バージョン分岐を意識せずに済みます。
+
+---
+
+### 変更
+
+#### `gbfs_now_stations.py`
+
+| 変更前 | 変更後 |
+|--------|--------|
+| `from qgis.PyQt.QtCore import QVariant` | `from .compat import FIELD_STRING, FIELD_INT, FIELD_DOUBLE, FIELD_BOOL` |
+| `QVariant.String` | `FIELD_STRING` |
+| `QVariant.Int` | `FIELD_INT` |
+| `QVariant.Double` | `FIELD_DOUBLE` |
+| `QVariant.Bool` | `FIELD_BOOL` |
+
+`QgsField()` の型指定を全箇所（英語版・日本語版の両関数）で置き換えました。
+
+#### `gbfs_now_stations_status.py`
+
+`gbfs_now_stations.py` と同様に `QVariant.*` を `compat.py` 経由の定数に置き換えました。
+
+#### `gbfs_now_free_bike_status.py`
+
+`gbfs_now_stations.py` と同様に `QVariant.*` を `compat.py` 経由の定数に置き換えました。
+
+#### `gbfs_now_vehicle_types.py`
+
+`QgsField` の定義はありませんでしたが、使用されていない `QVariant` の import を除去しました。
+
+#### `gbfs_now_search_dialog.py`
+
+1. **CSVカラム名のハードコードを廃止**
+   - `systems.csv` のカラム名をコード内に直書きしていたのをやめ、
+     `df.columns.tolist()` で取得したカラム名を `createTableModel()` に渡すようにしました。
+   - MobilityData がカラム名を変更しても、コード修正なしに追従できます。
+
+2. **`QDialog.Accepted` → `DIALOG_ACCEPTED`（compat 経由）**
+   - Qt 6 では `QDialog.Accepted` が `QDialog.DialogCode.Accepted` に変わりました。
+   - `compat.py` の `DIALOG_ACCEPTED` を使うことで、新旧 QGIS 両方で動作します。
+
+3. **不要な `QVariant` import を除去**
+
+---
+
+### 修正ファイル一覧
+
+```
+GBFS-NOW/
+├── compat.py                    ← 新規追加
+├── gbfs_now_stations.py         ← QVariant → compat 定数
+├── gbfs_now_stations_status.py  ← QVariant → compat 定数
+├── gbfs_now_free_bike_status.py ← QVariant → compat 定数
+├── gbfs_now_vehicle_types.py    ← 不要 QVariant import 除去
+└── gbfs_now_search_dialog.py    ← CSVカラム動的取得 / QDialog.Accepted 修正
+```
+
+---
+
+### 動作確認バージョン
+
+| QGIS バージョン | Qt バージョン | 動作 |
+|----------------|-------------|------|
+| 3.38 以降       | Qt 6         | ✅   |
+| 3.38 未満       | Qt 5         | ✅（後方互換）|

--- a/compat.py
+++ b/compat.py
@@ -1,0 +1,33 @@
+"""
+Compatibility helpers for QGIS 3.38+.
+
+QGIS 3.38 (Qt 6) replaced QVariant-based field types with QMetaType.Type.
+This module exposes unified constants so the rest of the plugin can import
+FIELD_STRING / FIELD_INT / FIELD_DOUBLE / FIELD_BOOL / DIALOG_ACCEPTED
+without worrying about which QGIS version is running.
+"""
+
+from qgis.core import Qgis
+from qgis.PyQt import QtWidgets
+
+if Qgis.versionInt() >= 33800:
+    # QGIS 3.38+ / Qt 6
+    from qgis.PyQt.QtCore import QMetaType
+
+    FIELD_STRING   = QMetaType.Type.QString
+    FIELD_INT      = QMetaType.Type.Int
+    FIELD_DOUBLE   = QMetaType.Type.Double
+    FIELD_BOOL     = QMetaType.Type.Bool
+
+    DIALOG_ACCEPTED = QtWidgets.QDialog.DialogCode.Accepted
+
+else:
+    # QGIS < 3.38 / Qt 5
+    from qgis.PyQt.QtCore import QVariant
+
+    FIELD_STRING   = QVariant.String
+    FIELD_INT      = QVariant.Int
+    FIELD_DOUBLE   = QVariant.Double
+    FIELD_BOOL     = QVariant.Bool
+
+    DIALOG_ACCEPTED = QtWidgets.QDialog.Accepted

--- a/gbfs_now_free_bike_status.py
+++ b/gbfs_now_free_bike_status.py
@@ -1,7 +1,7 @@
 import os, requests, json
 
 from qgis.core import *
-from qgis.PyQt.QtCore import QVariant
+from .compat import FIELD_STRING, FIELD_DOUBLE, FIELD_BOOL
 BIKE_PNG_PATH = os.path.join(os.path.dirname(__file__),  "bike.png")
 
 
@@ -25,23 +25,23 @@ def create_gbfs_free_bike_layer(self,url):
     
     #カラムを作成        
     layer.dataProvider().addAttributes( [
-        QgsField('bike_id'               , QVariant.String), 
-        QgsField('is_reserved'           , QVariant.Bool), 
-        QgsField('is_disabled'           , QVariant.Bool), 
-        QgsField('vehicle_type_id'       , QVariant.String), 
-        QgsField('last_reported'         , QVariant.String), 
-        QgsField('current_range_meters'  , QVariant.String), 
-        QgsField('current_fuel_percent'  , QVariant.String), 
-        QgsField('station_id'            , QVariant.String), 
-        QgsField('home_station_id'       , QVariant.String), 
-        QgsField('pricing_plan_id'       , QVariant.String), 
-        QgsField('vehicle_equipment'     , QVariant.String), 
-        QgsField('available_until'       , QVariant.String),
-        QgsField('android'               , QVariant.String), 
-        QgsField('ios '                  , QVariant.String), 
-        QgsField('web'                   , QVariant.String),  
-        QgsField('lon'                   , QVariant.Double), 
-        QgsField('lat'                   , QVariant.Double) 
+        QgsField('bike_id'               , FIELD_STRING), 
+        QgsField('is_reserved'           , FIELD_BOOL), 
+        QgsField('is_disabled'           , FIELD_BOOL), 
+        QgsField('vehicle_type_id'       , FIELD_STRING), 
+        QgsField('last_reported'         , FIELD_STRING), 
+        QgsField('current_range_meters'  , FIELD_STRING), 
+        QgsField('current_fuel_percent'  , FIELD_STRING), 
+        QgsField('station_id'            , FIELD_STRING), 
+        QgsField('home_station_id'       , FIELD_STRING), 
+        QgsField('pricing_plan_id'       , FIELD_STRING), 
+        QgsField('vehicle_equipment'     , FIELD_STRING), 
+        QgsField('available_until'       , FIELD_STRING),
+        QgsField('android'               , FIELD_STRING), 
+        QgsField('ios '                  , FIELD_STRING), 
+        QgsField('web'                   , FIELD_STRING),  
+        QgsField('lon'                   , FIELD_DOUBLE), 
+        QgsField('lat'                   , FIELD_DOUBLE) 
         ] )
     
     
@@ -108,23 +108,23 @@ def create_gbfs_free_bike_layer_jp(self,url):
     
     #カラムを作成        
     layer.dataProvider().addAttributes( [
-        QgsField('車両ID'                     , QVariant.String), 
-        QgsField('予約状況（True:予約中）'    , QVariant.Bool), 
-        QgsField('車両利用可否(True:利用不可)', QVariant.Bool), 
-        QgsField('車種ID'                     , QVariant.String), 
-        QgsField('ステータス最終取得時間'     , QVariant.String), 
-        QgsField('残走行可能距離(m)'          , QVariant.String), 
-        QgsField('残燃料(%)'                  , QVariant.String), 
-        QgsField('ステーションID'             , QVariant.String), 
-        QgsField('ホームステーションID'       , QVariant.String), 
-        QgsField('料金プランID'               , QVariant.String), 
-        QgsField('車両装備'                   , QVariant.String), 
-        QgsField('車両返却期限'               , QVariant.String),
-        QgsField('android'                    , QVariant.String), 
-        QgsField('ios '                       , QVariant.String), 
-        QgsField('web'                        , QVariant.String),  
-        QgsField('lon'                        , QVariant.Double), 
-        QgsField('lat'                        , QVariant.Double) 
+        QgsField('車両ID'                     , FIELD_STRING), 
+        QgsField('予約状況（True:予約中）'    , FIELD_BOOL), 
+        QgsField('車両利用可否(True:利用不可)', FIELD_BOOL), 
+        QgsField('車種ID'                     , FIELD_STRING), 
+        QgsField('ステータス最終取得時間'     , FIELD_STRING), 
+        QgsField('残走行可能距離(m)'          , FIELD_STRING), 
+        QgsField('残燃料(%)'                  , FIELD_STRING), 
+        QgsField('ステーションID'             , FIELD_STRING), 
+        QgsField('ホームステーションID'       , FIELD_STRING), 
+        QgsField('料金プランID'               , FIELD_STRING), 
+        QgsField('車両装備'                   , FIELD_STRING), 
+        QgsField('車両返却期限'               , FIELD_STRING),
+        QgsField('android'                    , FIELD_STRING), 
+        QgsField('ios '                       , FIELD_STRING), 
+        QgsField('web'                        , FIELD_STRING),  
+        QgsField('lon'                        , FIELD_DOUBLE), 
+        QgsField('lat'                        , FIELD_DOUBLE) 
         ] )
     
     

--- a/gbfs_now_search_dialog.py
+++ b/gbfs_now_search_dialog.py
@@ -4,9 +4,9 @@ import pandas as pd
 
 from qgis.core import *
 from qgis.PyQt import QtGui, QtWidgets, uic
-from qgis.PyQt.QtCore import pyqtSignal
-from qgis.PyQt.QtCore import QVariant
-from qgis.PyQt.QtCore import QSortFilterProxyModel
+from qgis.PyQt.QtCore import pyqtSignal, QSortFilterProxyModel
+
+from .compat import DIALOG_ACCEPTED
 
 from . import table_model
 
@@ -43,10 +43,12 @@ class gbfs_now_search_Dialog(QtWidgets.QDialog):
             contents = []
         else:
             contents = df.values.tolist()
-    
-        
+
+        # カラム名はCSVから動的に取得する（ハードコードしない）
+        columns = df.columns.tolist()
+
         #TableView更新
-        model = table_model.createTableModel(df.values.tolist(), ["Country Code","Name","Location","System ID","URL","Auto-Discovery URL","Supported Versions","Authentication Info"])
+        model = table_model.createTableModel(df.values.tolist(), columns)
         #self.gbfs_list.setModel(model)
         
         self.proxy_model = QSortFilterProxyModel()
@@ -69,4 +71,4 @@ class gbfs_now_search_Dialog(QtWidgets.QDialog):
             row_num  = self.gbfs_list.selectionModel().selectedRows()[0].row()
             gbfs_url = self.gbfs_list.model().index(row_num,5).data()
             
-        return (gbfs_url, result == QtWidgets.QDialog.Accepted)
+        return (gbfs_url, result == DIALOG_ACCEPTED)

--- a/gbfs_now_stations.py
+++ b/gbfs_now_stations.py
@@ -1,7 +1,7 @@
 import os, requests, json
 
 from qgis.core import *
-from qgis.PyQt.QtCore import QVariant
+from .compat import FIELD_STRING, FIELD_INT, FIELD_DOUBLE, FIELD_BOOL
 STATION_PNG_PATH = os.path.join(os.path.dirname(__file__),  "station.png")
 
 
@@ -25,29 +25,29 @@ def create_gbfs_station_layer(self,url):
     
     #カラムを作成        
     layer.dataProvider().addAttributes( [
-        QgsField('station_id'            , QVariant.String), 
-        QgsField('name'                  , QVariant.String), 
-        QgsField('short_name'            , QVariant.String), 
-        QgsField('capacity'              , QVariant.Int), 
-        QgsField('address'               , QVariant.String), 
-        QgsField('cross_street'          , QVariant.String), 
-        QgsField('region_id'             , QVariant.String), 
-        QgsField('post_code'             , QVariant.String), 
-        QgsField('rental_methods'        , QVariant.String), 
-        QgsField('is_virtual_station'    , QVariant.Bool),   
-        #QgsField('station_area'          , QVariant.String), 
-        QgsField('parking_type'          , QVariant.String), 
-        QgsField('parking_hoop'          , QVariant.Bool),   
-        QgsField('contact_phone '        , QVariant.String), 
-        #QgsField('vehicle_capacity'      , QVariant.String), 
-        QgsField('vehicle_type_capacity' , QVariant.String), 
-        QgsField('is_valet_station'      , QVariant.Bool),   
-        QgsField('is_charging_station'   , QVariant.Bool), 
-        QgsField('android'               , QVariant.String), 
-        QgsField('ios '                  , QVariant.String), 
-        QgsField('web'                   , QVariant.String),  
-        QgsField('lon'                   , QVariant.Double), 
-        QgsField('lat'                   , QVariant.Double) 
+        QgsField('station_id'            , FIELD_STRING), 
+        QgsField('name'                  , FIELD_STRING), 
+        QgsField('short_name'            , FIELD_STRING), 
+        QgsField('capacity'              , FIELD_INT), 
+        QgsField('address'               , FIELD_STRING), 
+        QgsField('cross_street'          , FIELD_STRING), 
+        QgsField('region_id'             , FIELD_STRING), 
+        QgsField('post_code'             , FIELD_STRING), 
+        QgsField('rental_methods'        , FIELD_STRING), 
+        QgsField('is_virtual_station'    , FIELD_BOOL),   
+        #QgsField('station_area'          , FIELD_STRING), 
+        QgsField('parking_type'          , FIELD_STRING), 
+        QgsField('parking_hoop'          , FIELD_BOOL),   
+        QgsField('contact_phone '        , FIELD_STRING), 
+        #QgsField('vehicle_capacity'      , FIELD_STRING), 
+        QgsField('vehicle_type_capacity' , FIELD_STRING), 
+        QgsField('is_valet_station'      , FIELD_BOOL),   
+        QgsField('is_charging_station'   , FIELD_BOOL), 
+        QgsField('android'               , FIELD_STRING), 
+        QgsField('ios '                  , FIELD_STRING), 
+        QgsField('web'                   , FIELD_STRING),  
+        QgsField('lon'                   , FIELD_DOUBLE), 
+        QgsField('lat'                   , FIELD_DOUBLE) 
         ] )
     
     
@@ -119,29 +119,29 @@ def create_gbfs_station_layer_jp(self,url):
     
     #カラムを作成        
     layer.dataProvider().addAttributes( [
-        QgsField('ステーションID'            , QVariant.String), 
-        QgsField('ステーション名'                  , QVariant.String), 
-        QgsField('ステーション名_略称'            , QVariant.String), 
-        QgsField('最大駐輪可能台数（ラック数）'              , QVariant.String),
-        QgsField('住所'               , QVariant.String), 
-        QgsField('道路・交差点名称'          , QVariant.String), 
-        QgsField('リージョンID'             , QVariant.String), 
-        QgsField('郵便番号'             , QVariant.String), 
-        QgsField('決済方法'        , QVariant.String),   
-        QgsField('仮想ステーションフラグ'    , QVariant.Bool), 
-        #QgsField('仮想ステーション領域'          , QVariant.String), 
-        QgsField('駐輪場種別'          , QVariant.String), 
-        QgsField('駐輪フープフラグ'          , QVariant.Bool), 
-        QgsField('電話番号'        , QVariant.String),  
-        #QgsField('vehicle_capacity'      , QVariant.String), 
-        QgsField('vehicle_type_capacity' , QVariant.String), 
-        QgsField('係員フラグ'      , QVariant.String), 
-        QgsField('チャージャーステーションフラグ'   , QVariant.Bool), 
-        QgsField('android-uri'               , QVariant.String), 
-        QgsField('ios-uri'                  , QVariant.String), 
-        QgsField('web-uri'                   , QVariant.String),
-        QgsField('lon'                   , QVariant.Double), 
-        QgsField('lat'                   , QVariant.Double) 
+        QgsField('ステーションID'            , FIELD_STRING), 
+        QgsField('ステーション名'                  , FIELD_STRING), 
+        QgsField('ステーション名_略称'            , FIELD_STRING), 
+        QgsField('最大駐輪可能台数（ラック数）'              , FIELD_STRING),
+        QgsField('住所'               , FIELD_STRING), 
+        QgsField('道路・交差点名称'          , FIELD_STRING), 
+        QgsField('リージョンID'             , FIELD_STRING), 
+        QgsField('郵便番号'             , FIELD_STRING), 
+        QgsField('決済方法'        , FIELD_STRING),   
+        QgsField('仮想ステーションフラグ'    , FIELD_BOOL), 
+        #QgsField('仮想ステーション領域'          , FIELD_STRING), 
+        QgsField('駐輪場種別'          , FIELD_STRING), 
+        QgsField('駐輪フープフラグ'          , FIELD_BOOL), 
+        QgsField('電話番号'        , FIELD_STRING),  
+        #QgsField('vehicle_capacity'      , FIELD_STRING), 
+        QgsField('vehicle_type_capacity' , FIELD_STRING), 
+        QgsField('係員フラグ'      , FIELD_STRING), 
+        QgsField('チャージャーステーションフラグ'   , FIELD_BOOL), 
+        QgsField('android-uri'               , FIELD_STRING), 
+        QgsField('ios-uri'                  , FIELD_STRING), 
+        QgsField('web-uri'                   , FIELD_STRING),
+        QgsField('lon'                   , FIELD_DOUBLE), 
+        QgsField('lat'                   , FIELD_DOUBLE) 
         ] )
     
     

--- a/gbfs_now_stations_status.py
+++ b/gbfs_now_stations_status.py
@@ -1,7 +1,7 @@
 import os,requests, json ,datetime
 
 from qgis.core import *
-from qgis.PyQt.QtCore import QVariant
+from .compat import FIELD_STRING, FIELD_INT, FIELD_BOOL
 
 STATION_PNG_PATH = os.path.join(os.path.dirname(__file__),  "station_now.png")
 
@@ -23,15 +23,15 @@ def create_gbfs_station_now_layer(self,url):
     
     #カラムを作成        
     layer.dataProvider().addAttributes( [
-        QgsField('station_id'            , QVariant.String), 
-        QgsField('name'                  , QVariant.String), 
-        QgsField('capacity'              , QVariant.Int), 
-        QgsField('num_bikes_available'   , QVariant.Int),
-        QgsField('num_docks_available'   , QVariant.Int),
-        QgsField('num_bikes_disabled'    , QVariant.Int),
-        QgsField('is_renting'            , QVariant.Bool),
-        QgsField('is_returning'          , QVariant.Bool),
-        QgsField('last_reported'         , QVariant.String)
+        QgsField('station_id'            , FIELD_STRING), 
+        QgsField('name'                  , FIELD_STRING), 
+        QgsField('capacity'              , FIELD_INT), 
+        QgsField('num_bikes_available'   , FIELD_INT),
+        QgsField('num_docks_available'   , FIELD_INT),
+        QgsField('num_bikes_disabled'    , FIELD_INT),
+        QgsField('is_renting'            , FIELD_BOOL),
+        QgsField('is_returning'          , FIELD_BOOL),
+        QgsField('last_reported'         , FIELD_STRING)
         ] )
     
     
@@ -102,15 +102,15 @@ def create_gbfs_station_now_layer_jp(self,url):
     
     #カラムを作成        
     layer.dataProvider().addAttributes( [
-        QgsField('ステーションID'            , QVariant.String), 
-        QgsField('ステーション名'                  , QVariant.String), 
-        QgsField('最大駐輪可能台数（ラック数）'              , QVariant.Int), 
-        QgsField('貸出可能台数'   , QVariant.Int),
-        QgsField('返却可能台数'   , QVariant.Int),
-        QgsField('駐輪不可ラック数'    , QVariant.Int),
-        QgsField('貸出可能時間'            , QVariant.Bool),
-        QgsField('返却可能時間'          , QVariant.Bool),
-        QgsField('データ更新時間'         , QVariant.String)
+        QgsField('ステーションID'            , FIELD_STRING), 
+        QgsField('ステーション名'                  , FIELD_STRING), 
+        QgsField('最大駐輪可能台数（ラック数）'              , FIELD_INT), 
+        QgsField('貸出可能台数'   , FIELD_INT),
+        QgsField('返却可能台数'   , FIELD_INT),
+        QgsField('駐輪不可ラック数'    , FIELD_INT),
+        QgsField('貸出可能時間'            , FIELD_BOOL),
+        QgsField('返却可能時間'          , FIELD_BOOL),
+        QgsField('データ更新時間'         , FIELD_STRING)
         ] )
     
     

--- a/gbfs_now_vehicle_types.py
+++ b/gbfs_now_vehicle_types.py
@@ -1,6 +1,6 @@
 import requests, json, os
 from qgis.core import *
-from qgis.PyQt.QtCore import QVariant, Qt, QAbstractTableModel, QUrl
+from qgis.PyQt.QtCore import Qt, QAbstractTableModel, QUrl
 from qgis.PyQt.QtGui import QIcon, QPixmap
 
 from qgis.PyQt.QtNetwork import QNetworkAccessManager, QNetworkRequest,QNetworkReply


### PR DESCRIPTION
## 概要

QGIS 3.38 から Qt 6 ベースに移行したことで、
`QVariant` を使ったフィールド型指定などが動かなくなったので修正しました。
**QGIS 3.38 未満でも引き続き動作します**（後方互換あり）。

## 変更内容

### 新規追加: `compat.py`
バージョン判定を一箇所にまとめたヘルパーファイルです。
- QGIS 3.38 以上 → `QMetaType.Type.QString` など Qt 6 スタイル
- QGIS 3.38 未満 → `QVariant.String` など従来スタイル

各ファイルはここから定数を import するだけでよくなります。

### `gbfs_now_stations.py` / `gbfs_now_stations_status.py` / `gbfs_now_free_bike_status.py`
`QgsField()` の型指定（String / Int / Double / Bool）を
`QVariant.*` から `compat.py` 経由の定数に全置換しました。

### `gbfs_now_vehicle_types.py`
使っていない `QVariant` の import を削除しました。

### `gbfs_now_search_dialog.py`
- `systems.csv` のカラム名をハードコードしていたのをやめ、
  `df.columns.tolist()` で動的に取得するようにしました
  （MobilityData 側でカラム名が変わっても壊れなくなります）
- `QDialog.Accepted` → `compat.py` の `DIALOG_ACCEPTED` に変更（Qt 6 対応）

詳細は [CHANGELOG.md](CHANGELOG.md) も見てください！